### PR TITLE
restart dxgrabber when a DXGI_ERROR_WAIT_TIMEOUT happens

### DIFF
--- a/include/grabber/windows/DX/DxGrabber.h
+++ b/include/grabber/windows/DX/DxGrabber.h
@@ -39,7 +39,7 @@ template <class T> void SafeRelease(T** ppT)
 struct DisplayHandle
 {
 	QString name;
-	int warningCounter = 6;
+	int warningCounter = 15;
 	bool wideGamut = false;
 	int actualDivide = -1, actualWidth = 0, actualHeight = 0;
 	uint targetMonitorNits = 0;

--- a/sources/grabber/windows/DX/DxGrabber.cpp
+++ b/sources/grabber/windows/DX/DxGrabber.cpp
@@ -370,7 +370,7 @@ bool DxGrabber::initDirectX(QString selectedDeviceName)
 							_d3dContext = nullptr;
 						}
 					}
-					
+
 					if (_d3dDevice != nullptr)
 					{
 						HRESULT status = E_FAIL;
@@ -425,7 +425,7 @@ bool DxGrabber::initDirectX(QString selectedDeviceName)
 							int targetSizeX = display->surfaceProperties.ModeDesc.Width, targetSizeY = display->surfaceProperties.ModeDesc.Height;
 
 							if (_hardware)
-							{								
+							{
 								display->actualWidth = targetSizeX;
 								display->actualHeight = targetSizeY;
 
@@ -477,7 +477,7 @@ bool DxGrabber::initDirectX(QString selectedDeviceName)
 								{
 									result = initShaders(*display);
 									if (result)
-									{										
+									{
 										Info(_log, "The DX11 device has been initialized. Hardware acceleration is enabled");
 										_handles.emplace_back(std::move(display));
 									}
@@ -485,7 +485,7 @@ bool DxGrabber::initDirectX(QString selectedDeviceName)
 									{
 										Error(_log, "CreateShaders failed");
 										uninit();
-									}	
+									}
 								}
 								else
 								{
@@ -591,7 +591,7 @@ bool DxGrabber::initShaders(DisplayHandle& display)
 			shaderDesc.Format = descConvert->Format;
 			shaderDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
 			shaderDesc.Texture2D.MipLevels = descConvert->MipLevels;;
-			
+
 			status = _d3dDevice->CreateShaderResourceView(display.d3dConvertTexture, &shaderDesc, &display.d3dConvertTextureView);
 			return CHECK(status);
 		}
@@ -701,10 +701,10 @@ bool DxGrabber::initShaders(DisplayHandle& display)
 
 HRESULT DxGrabber::deepScaledCopy(DisplayHandle& display, ID3D11Texture2D* source)
 {
-	HRESULT status = S_OK;	
-	
+	HRESULT status = S_OK;
+
 	if (display.actualDivide >= 0)
-	{		
+	{
 		_d3dContext->CopySubresourceRegion(display.d3dConvertTexture, 0, 0, 0, 0, source, 0, NULL);
 		_d3dContext->GenerateMips(display.d3dConvertTextureView);
 		_d3dContext->CopySubresourceRegion(display.d3dSourceTexture, 0, 0, 0, 0, display.d3dConvertTexture, display.actualDivide, NULL);
@@ -753,7 +753,7 @@ void DxGrabber::grabFrame()
 {
 	if (_handles.size() == 0)
 		return;
-	
+
 	if (_multiMonitor)
 	{
 		int width = 0;
@@ -978,6 +978,7 @@ int DxGrabber::captureFrame(DisplayHandle& display, Image<ColorRgb>& image)
 
 				result = 1;
 				_d3dContext->Unmap(display.d3dSourceTexture, 0);
+				display.warningCounter = 15;
 			}
 
 			SafeRelease(&texDesktop);
@@ -1019,6 +1020,7 @@ int DxGrabber::captureFrame(DisplayHandle& display, Image<ColorRgb>& image)
 	if (_dxRestartNow)
 	{
 		uninit();
+		display.warningCounter = 15;
 	}
 
 	return result;

--- a/sources/grabber/windows/DX/DxGrabber.cpp
+++ b/sources/grabber/windows/DX/DxGrabber.cpp
@@ -892,7 +892,7 @@ void DxGrabber::captureFrame(DisplayHandle& display)
 		else if (display.warningCounter > 0)
 		{
 			Error(_log, "ResourceDesktop->QueryInterface failed. Reason: %i", status);
-			display.warningCounter--;
+ //			display.warningCounter--;
 		}
 	}
 	else if (status == DXGI_ERROR_WAIT_TIMEOUT)
@@ -900,7 +900,7 @@ void DxGrabber::captureFrame(DisplayHandle& display)
 		if (display.warningCounter > 0)
 		{
 			Debug(_log, "AcquireNextFrame didn't return the frame. Just warning: the screen has not changed?");
-			display.warningCounter--;
+//			display.warningCounter--;
 		}
 
 		if (_cacheImage.width() > 1)
@@ -916,7 +916,7 @@ void DxGrabber::captureFrame(DisplayHandle& display)
 	else if (display.warningCounter > 0)
 	{
 		Error(_log, "AcquireNextFrame failed. Reason: %i", status);
-		display.warningCounter--;
+//		display.warningCounter--;
 	}
 
 	SafeRelease(&resourceDesktop);
@@ -978,7 +978,6 @@ int DxGrabber::captureFrame(DisplayHandle& display, Image<ColorRgb>& image)
 
 				result = 1;
 				_d3dContext->Unmap(display.d3dSourceTexture, 0);
-				display.warningCounter = 15;
 			}
 
 			SafeRelease(&texDesktop);
@@ -986,7 +985,7 @@ int DxGrabber::captureFrame(DisplayHandle& display, Image<ColorRgb>& image)
 		else if (display.warningCounter > 0)
 		{
 			Error(_log, "ResourceDesktop->QueryInterface failed. Reason: %i", status);
-			display.warningCounter--;
+//			display.warningCounter--;
 		}
 	}
 	else if (status == DXGI_ERROR_WAIT_TIMEOUT)
@@ -994,7 +993,7 @@ int DxGrabber::captureFrame(DisplayHandle& display, Image<ColorRgb>& image)
 		if (display.warningCounter > 0)
 		{
 			Debug(_log, "AcquireNextFrame didn't return the frame. Just warning: the screen has not changed?");
-			display.warningCounter--;
+//			display.warningCounter--;
 		}
 
 		if (_cacheImage.width() > 1)
@@ -1010,7 +1009,7 @@ int DxGrabber::captureFrame(DisplayHandle& display, Image<ColorRgb>& image)
 	else if (display.warningCounter > 0)
 	{
 		Error(_log, "AcquireNextFrame failed. Reason: %i", status);
-		display.warningCounter--;
+//		display.warningCounter--;
 	}
 
 	SafeRelease(&resourceDesktop);
@@ -1020,7 +1019,6 @@ int DxGrabber::captureFrame(DisplayHandle& display, Image<ColorRgb>& image)
 	if (_dxRestartNow)
 	{
 		uninit();
-		display.warningCounter = 15;
 	}
 
 	return result;


### PR DESCRIPTION
this should fix the issue where the grabber is unresponsive after switching an application to exclusive fullscreen mode

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**



**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of web configuration, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing setups:

**The PR fulfills these requirements:**
<!-- Github will close properly linked issues automatically on PR merge -->
- [ ] When resolving a specific issue, it's referenced in the PR's body (e.g. `Fixes: #xxx[,#xxx]`, where "xxx" is the issue number)

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
